### PR TITLE
[MDP-1723] fix PMem simulation on K8S

### DIFF
--- a/0.0.10/scripts/config-pmem.sh
+++ b/0.0.10/scripts/config-pmem.sh
@@ -225,6 +225,10 @@ spec:
           # Need bidirectional propagation, so that the mount happened inside the container actually
           # happens on th host as well.
           mountPropagation: Bidirectional
+        - name: shm
+          mountPath: /dev/shm
+        - name: hugepages
+          mountPath: /dev/hugepages
         - name: host
           mountPath: /host
         - name: pmem-config
@@ -245,6 +249,14 @@ spec:
       - name: mnt
         hostPath:
           path: /mnt
+          type: Directory
+      - name: shm
+        hostPath:
+          path: /dev/shm
+          type: Directory
+      - name: hugepages
+        hostPath:
+          path: /dev/hugepages
           type: Directory
       - name: host
         hostPath:


### PR DESCRIPTION
**Problem**: On K8S with docker as container runtime, host's `/dev/shm` directory is not mapped into the config container, even the whole `/dev` is mapped. It causes `fallocate` to fail because now the config container has its own `/dev/shm`.

**Solution**: Explicitly map `/dev/shm` into the config container.

**Testing Done**: Tested on a Kubernetes cluster.