### PR TITLE
[MDP-1733]Add storageClass information of etcd

### DIFF
--- a/0.0.10/README.md
+++ b/0.0.10/README.md
@@ -12,6 +12,8 @@ You must have a Kubernetes cluster deployed, and the `kubectl` command-line tool
 
 The [Operator SDK](https://sdk.operatorframework.io/docs/installation/) is a framework used to develop and run Operators. You will use the `operator-sdk` command to run the Memory Machine Operator, so you must have the Operator SDK installed.
 
+Please be sure to have a StorageClass that supports dynamic provisioning. You can change the StorageClass in ```etcdConfig```. Please see [MemoryMachine Configuration List](config.md)
+
 ## Configuring the Memory Machine Platform
 
 Before installing Memory Machine Operator, complete the steps described below.

--- a/0.0.10/config.md
+++ b/0.0.10/config.md
@@ -125,3 +125,10 @@ Configurations for MemoryMachine can be specified in the spec field of the Memor
     - Default value: "/tmp/libmvm_sock"
   - Daemonize `bool`
   - LogTrace `bool`
+
+## etcdConfig
+
+- Configuration for etcd
+- Configurable parameters:
+  - storageClass `string`
+  - image `string`	

--- a/0.0.10/example.md
+++ b/0.0.10/example.md
@@ -35,6 +35,8 @@ metadata:
 spec:
   mmVersion: "2.4.0"
   controlVersion: "2.4.0"
+  etcdConfig:
+    storageClass: <storage class>
 ```
 Explanation of parameters:
 - apiVersion: memverge.memverge.com/v1alpha1 : version of resource API is v1alpha1


### PR DESCRIPTION
Add storageClass information of etcd. 
etcd is required to have a external storage class that supports dynamic provisioning. 

